### PR TITLE
feat: integrate sidecar gui auto-launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 build/
 out/
 
+# downloaded sidecar binary
+bin/
+
 # 日志文件
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A Node.js/TypeScript-based interactive AI agent system that provides a rich Web 
 
 - **Multi-modal Interaction**: Support for text and image inputs with real-time feedback
 - **Web Notifications**: Browser-native notifications ensure you never miss important messages, even when the tab is in the background
+- **Desktop GUI**: Automatically downloads and opens the interface in a Sidecar window
 - **Dual MCP Tools**:
   - `solicit-input`: Interactive mode that collects user feedback through a web interface
   - `notify-user`: Notification mode that sends information to users without waiting for response
@@ -48,6 +49,8 @@ A Node.js/TypeScript-based interactive AI agent system that provides a rich Web 
    pnpm run build
    make link  # Links as global CLI tool
    ```
+
+During installation, the appropriate Sidecar binary is downloaded automatically so the desktop GUI works out of the box.
 
 ### Usage
 
@@ -100,6 +103,7 @@ Environment variables can be configured via `.env` file or direct export:
 | `SESSION_TIMEOUT`  | Session timeout in seconds                 | `300`        |
 | `TIMEOUT_PROMPT`   | Default prompt on session timeout          | `"continue"` |
 | `DEFAULT_LANGUAGE` | Default interface language ("zh"、"en" 等) | "zh"         |
+| `AUTO_OPEN_SIDECAR` | Launch Sidecar desktop GUI on server start | `true`       |
 
 ### Logging Configuration
 

--- a/docs/README-zh.md
+++ b/docs/README-zh.md
@@ -8,6 +8,7 @@
 
 - **多模态交互**：支持文本和图片输入，提供实时反馈
 - **Web 通知系统**：浏览器原生通知确保用户不会错过重要信息，即使在后台标签页也能及时提醒
+- **桌面 GUI**：安装时自动下载 Sidecar，服务器启动后会在独立窗口中打开界面
 - **双重 MCP 工具**：
   - `solicit-input`：交互模式，通过 Web 界面收集用户反馈
   - `notify-user`：通知模式，向用户发送信息而无需等待响应
@@ -46,6 +47,8 @@
    pnpm run build
    make link  # 链接为全局 CLI 工具
    ```
+
+安装过程中会自动下载适合当前平台的 Sidecar 二进制文件，GUI 开箱即用。
 
 ### 使用方法
 
@@ -100,6 +103,7 @@ pnpm run build
 | `SESSION_TIMEOUT`  | 会话超时时间（秒）            | `300`        |
 | `DEFAULT_LANGUAGE` | 默认界面语言（`zh`、`en` 等） | `zh`         |
 | `TIMEOUT_PROMPT`   | 会话超时时的默认提示          | `"continue"` |
+| `AUTO_OPEN_SIDECAR` | 服务器启动后自动尝试启动 Sidecar GUI | `true`       |
 
 ### 日志配置
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "dynamic-interaction": "dist/src/cli.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "scripts"
   ],
   "types": "dist/src/index.d.ts",
   "engines": {
@@ -34,7 +35,8 @@
     "build:frontend": "tsc --project tsconfig.frontend.json",
     "copy-assets": "mkdir -p dist/src/public/js && cp -r dist/frontend/public/ts/* dist/src/public/js/ && cp -r src/public/css dist/src/public/ && cp src/public/index.html dist/src/public/ && rm -rf dist/src/public/ts",
     "start": "node dist/src/index.js",
-    "dev": "nodemon --watch 'src/**/*.ts' --exec ts-node src/index.ts"
+    "dev": "nodemon --watch 'src/**/*.ts' --exec ts-node src/index.ts",
+    "postinstall": "node scripts/install-sidecar.js"
   },
   "keywords": [
     "dynamic-interaction",
@@ -43,7 +45,7 @@
     "windsurf",
     "trae"
   ],
-  "packageManager": "pnpm@9.10.0^",
+  "packageManager": "pnpm@9.10.0",
   "devDependencies": {
     "@types/express": "^5.0.3",
     "@types/multer": "^1.4.13",

--- a/scripts/install-sidecar.js
+++ b/scripts/install-sidecar.js
@@ -1,0 +1,108 @@
+const { platform, arch } = require('os');
+const { existsSync, mkdirSync, createWriteStream, chmodSync, unlinkSync } = require('fs');
+const { join, extname, basename } = require('path');
+const { spawn } = require('child_process');
+const https = require('https');
+
+const REPO = 'stone2401/Sidecar';
+const VERSION = process.env.SIDECAR_VERSION || 'latest';
+
+function getAsset() {
+  const p = platform();
+  const a = arch();
+  const platformMap = { win32: 'windows', darwin: 'macos', linux: 'linux' };
+  const archMap = { x64: 'x64', arm64: 'arm64' };
+  const plat = platformMap[p];
+  const architecture = archMap[a];
+  if (!plat || !architecture) return null;
+  return `Sidecar-${plat}-${architecture}`;
+}
+
+async function fetchJson(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers: { 'User-Agent': 'dynamic-interaction' } }, (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Request failed with status ${res.statusCode}`));
+          return;
+        }
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(data));
+          } catch (err) {
+            reject(err);
+          }
+        });
+      })
+      .on('error', reject);
+  });
+}
+
+async function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const file = createWriteStream(dest);
+    https
+      .get(url, (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Download failed with status ${res.statusCode}`));
+          return;
+        }
+        res.pipe(file);
+        file.on('finish', () => file.close(resolve));
+      })
+      .on('error', (err) => {
+        unlinkSync(dest);
+        reject(err);
+      });
+  });
+}
+
+async function install() {
+  try {
+    const assetPrefix = getAsset();
+    if (!assetPrefix) {
+      console.warn('Unsupported platform for Sidecar');
+      return;
+    }
+    const releaseInfoUrl =
+      VERSION === 'latest'
+        ? `https://api.github.com/repos/${REPO}/releases/latest`
+        : `https://api.github.com/repos/${REPO}/releases/tags/${VERSION}`;
+    const release = await fetchJson(releaseInfoUrl);
+    const asset = release.assets.find((a) => a.name.startsWith(assetPrefix));
+    if (!asset) {
+      console.warn('No prebuilt Sidecar binary for this platform');
+      return;
+    }
+    const dir = join(__dirname, '..', 'bin');
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const archivePath = join(dir, asset.name);
+    await download(asset.browser_download_url, archivePath);
+
+    const ext = extname(asset.name);
+    if (ext === '.zip') {
+      await new Promise((resolve, reject) => {
+        const unzip = spawn('unzip', ['-o', archivePath, '-d', dir], { stdio: 'ignore' });
+        unzip.on('close', (code) => (code === 0 ? resolve() : reject(new Error('unzip failed'))));
+      });
+      unlinkSync(archivePath);
+    } else if (ext === '.gz') {
+      await new Promise((resolve, reject) => {
+        const tar = spawn('tar', ['-xzf', archivePath, '-C', dir], { stdio: 'ignore' });
+        tar.on('close', (code) => (code === 0 ? resolve() : reject(new Error('tar failed'))));
+      });
+      unlinkSync(archivePath);
+    }
+
+    const execName = platform() === 'win32' ? 'sidecar.exe' : 'sidecar';
+    const execPath = join(dir, execName);
+    if (existsSync(execPath)) chmodSync(execPath, 0o755);
+    console.log(`Sidecar binary ready at ${execPath}`);
+  } catch (err) {
+    console.warn('Failed to install Sidecar:', err.message || err);
+  }
+}
+
+install();

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,9 @@ export const DEFAULT_LANGUAGE = process.env.DEFAULT_LANGUAGE || 'zh';
 // 会话租约超时时间（秒），用于处理中的任务
 export const SESSION_TIMEOUT = Number(process.env.SESSION_TIMEOUT) || 300; // 默认 5 分钟
 
+// 是否在服务器启动后自动尝试打开 Sidecar GUI
+export const AUTO_OPEN_SIDECAR = process.env.AUTO_OPEN_SIDECAR !== 'false';
+
 // 日志配置
 export const LOG_CONFIG = {
     // 是否启用日志系统

--- a/src/server/core/lifecycle.ts
+++ b/src/server/core/lifecycle.ts
@@ -3,7 +3,6 @@
  * 负责管理服务器的启动、停止和状态
  */
 
-import { Server } from 'http';
 import { logger } from '../../logger';
 import { httpServer } from './server';
 import { webSocketManager } from '../websocket/connection';
@@ -11,6 +10,8 @@ import { sessionManager } from '../session/manager';
 import { sessionQueue } from '../session/queue';
 import { ServerState } from '../utils/types';
 import { ServerError, ErrorCodes } from '../utils/errors';
+import { AUTO_OPEN_SIDECAR } from '../../config';
+import { launchSidecar } from '../utils/sidecar';
 
 export class LifecycleManager {
   private static instance: LifecycleManager;
@@ -54,6 +55,11 @@ export class LifecycleManager {
       
       // 初始化WebSocket服务器
       webSocketManager.initialize(httpServer.getServer());
+
+      // 尝试启动 Sidecar GUI
+      if (AUTO_OPEN_SIDECAR) {
+        launchSidecar();
+      }
 
       this._state = ServerState.RUNNING;
       this._startTime = Date.now();

--- a/src/server/utils/sidecar.ts
+++ b/src/server/utils/sidecar.ts
@@ -1,0 +1,29 @@
+import { spawn } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { logger } from '../../logger';
+import { PORT } from '../../config';
+
+/**
+ * 尝试启动 Sidecar GUI
+ * 如果命令不存在或启动失败，不会抛出错误
+ */
+export function launchSidecar(): void {
+  const url = `http://localhost:${PORT}`;
+  const execName = process.platform === 'win32' ? 'sidecar.exe' : 'sidecar';
+  const localPath = join(__dirname, '../../..', 'bin', execName);
+  const cmd = existsSync(localPath) ? localPath : 'sidecar';
+  try {
+    const child = spawn(cmd, ['--url', url], {
+      detached: true,
+      stdio: 'ignore'
+    });
+    child.on('error', (err) => {
+      logger.warn(`Sidecar 启动失败: ${err.message}`);
+    });
+    child.unref();
+    logger.info(`尝试通过 Sidecar 打开 GUI: ${url}`);
+  } catch (err) {
+    logger.warn(`无法启动 Sidecar: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}


### PR DESCRIPTION
## Summary
- download platform-specific Sidecar binary during `postinstall`
- prefer bundled Sidecar executable when launching the GUI
- document automatic Sidecar setup and ignore downloaded binaries

## Testing
- `pnpm install` (fails: RequestAbortedError [AbortError]: Proxy response (403) !== 200 when HTTP Tunneling)
- `pnpm run build` (fails: RequestAbortedError [AbortError]: Proxy response (403) !== 200 when HTTP Tunneling)

------
https://chatgpt.com/codex/tasks/task_b_68a72d570fd08331ba575c1ec7a42a46